### PR TITLE
TwoPhotonSeries color mode

### DIFF
--- a/nwbwidgets/controllers/image_controllers.py
+++ b/nwbwidgets/controllers/image_controllers.py
@@ -74,7 +74,7 @@ class ContrastTypeController(widgets.VBox):
 
 
 class ColorModeController(widgets.VBox):
-    controller_fields = ("color_mode_dropdown", "supported_colors", "color_mode_reverse_toggle")
+    controller_fields = ("color_mode_dropdown", "supported_colors", "color_mode_reverse_toggle", "color_mode")
     
     def __init__(self):
         super().__init__()
@@ -93,6 +93,7 @@ class ColorModeController(widgets.VBox):
             value="greys",
             layout=dict(width="max-content")
         )
+        self.color_mode = "greys"
         self.color_mode_reverse_toggle = widgets.ToggleButtons(
             options=[
                 ("Normal", "Normal"),
@@ -100,10 +101,16 @@ class ColorModeController(widgets.VBox):
             ],  # Values set to strings for external readability
         )
         
-        # Ran into problems with race conditions with setting up observers for this one
-        # Mostly because simultaneous modifications of options/values of a dropdown
+        self.color_mode_dropdown.observe(lambda change: self.update_color_mode(change.new), names="value")
+        self.color_mode_reverse_toggle.observe(lambda change: self.update_color_mode(change.new), names="value")
         
         self.children = (self.color_mode_dropdown, self.color_mode_reverse_toggle)
+        
+    def update_color_mode(self, change):
+        if self.color_mode_reverse_toggle.value == "Normal":
+            self.color_mode = self.color_mode_dropdown.value
+        elif self.color_mode_reverse_toggle.value == "Reversed":
+            self.color_mode = self.color_mode_dropdown.value + "_r"
 
 
 class ImShowController(MultiController):

--- a/nwbwidgets/controllers/image_controllers.py
+++ b/nwbwidgets/controllers/image_controllers.py
@@ -1,4 +1,7 @@
 import ipywidgets as widgets
+import plotly.express as px
+
+from .multicontroller import MultiController
 
 
 class RotationController(widgets.HBox):
@@ -26,11 +29,11 @@ class RotationController(widgets.HBox):
         self.rotate_left.on_click(_rotate_left)
 
 
-class ImShowController(widgets.VBox):
-    """Controller specifically for handling various options for the plot.express.imshow function."""
+class ContrastTypeController(widgets.VBox):
+    """Controller specifically for handling contrastt options for the plotly.express.imshow function."""
 
     controller_fields = ("contrast_type_toggle", "auto_contrast_method", "manual_contrast_slider")
-
+    
     def __init__(self):
         super().__init__()
 
@@ -68,3 +71,31 @@ class ImShowController(widgets.VBox):
             self.children = (self.contrast_type_toggle, self.manual_contrast_slider)
         elif self.contrast_type_toggle.value == "Automatic":
             self.children = (self.contrast_type_toggle, self.auto_contrast_method)
+
+
+class ColorModeController(widgets.VBox):
+    controller_fields = ("color_mode_dropdown", "supported_colors")
+    
+    def __init__(self):
+        super().__init__()
+
+        self.supported_colors = {name.capitalize(): name for name in px.colors.named_colorscales()}
+
+        # Remap name of 'greys' and denote as default
+        # Also setting up the name map and linking it to controller just in case we ever want to customize it more
+        default_color = ("Grayscale (default)", "greys")
+        self.supported_colors.pop(default_color[1].capitalize())
+        self.supported_colors.update({default_color[0]: default_color[1]})
+
+        self.color_mode_dropdown = widgets.Dropdown(options=[(k,v) for k,v in self.supported_colors.items()], value="greys")
+
+        self.children = (self.color_mode_dropdown,)
+        
+
+class ImShowController(MultiController):
+    """Controller specifically for handling various options for the plotly.express.imshow function."""
+
+    controller_fields = ("contrast_type_toggle", "auto_contrast_method", "manual_contrast_slider")
+
+    def __init__(self):
+        super().__init__(components=[ContrastTypeController(), ColorModeController()])

--- a/nwbwidgets/controllers/image_controllers.py
+++ b/nwbwidgets/controllers/image_controllers.py
@@ -65,7 +65,7 @@ class ContrastTypeController(widgets.VBox):
             lambda change: self.switch_contrast_modes(enable_manual_contrast=change.new), names="value"
         )
 
-    def switch_contrast_modes(self, enable_manual_contrast: bool):
+    def switch_contrast_modes(self, enable_manual_contrast: str):
         """When the manual contrast toggle is altered, adjust the manual vs. automatic visibility of the components."""
         if self.contrast_type_toggle.value == "Manual":
             self.children = (self.contrast_type_toggle, self.manual_contrast_slider)
@@ -74,7 +74,7 @@ class ContrastTypeController(widgets.VBox):
 
 
 class ColorModeController(widgets.VBox):
-    controller_fields = ("color_mode_dropdown", "supported_colors")
+    controller_fields = ("color_mode_dropdown", "supported_colors", "color_mode_reverse_toggle")
     
     def __init__(self):
         super().__init__()
@@ -87,10 +87,24 @@ class ColorModeController(widgets.VBox):
         self.supported_colors.pop(default_color[1].capitalize())
         self.supported_colors.update({default_color[0]: default_color[1]})
 
-        self.color_mode_dropdown = widgets.Dropdown(options=[(k,v) for k,v in self.supported_colors.items()], value="greys")
-
-        self.children = (self.color_mode_dropdown,)
+        self.color_mode_dropdown = widgets.Dropdown(
+            description="Color Mode: ",
+            options=[(k,v) for k,v in self.supported_colors.items()],
+            value="greys",
+            layout=dict(width="max-content")
+        )
+        self.color_mode_reverse_toggle = widgets.ToggleButtons(
+            options=[
+                ("Normal", "Normal"),
+                ("Reversed", "Reversed"),
+            ],  # Values set to strings for external readability
+        )
         
+        # Ran into problems with race conditions with setting up observers for this one
+        # Mostly because simultaneous modifications of options/values of a dropdown
+        
+        self.children = (self.color_mode_dropdown, self.color_mode_reverse_toggle)
+
 
 class ImShowController(MultiController):
     """Controller specifically for handling various options for the plotly.express.imshow function."""

--- a/nwbwidgets/ophys/ophys_controllers.py
+++ b/nwbwidgets/ophys/ophys_controllers.py
@@ -74,6 +74,9 @@ class BasePlaneSliceController(MultiController):
         self.manual_contrast_slider.layout.visibility = widget_visibility_type
         self.auto_contrast_method.layout.visibility = widget_visibility_type
 
+        self.color_mode_dropdown.layout.visibility = widget_visibility_type
+        self.color_mode_reverse_toggle.layout.visibility = widget_visibility_type
+
     def update_visibility(self):
         if self.view_type_toggle.value == "Simplified":
             self.set_detailed_visibility(visibile=False)

--- a/nwbwidgets/ophys/plane_slice.py
+++ b/nwbwidgets/ophys/plane_slice.py
@@ -75,12 +75,19 @@ class PlaneSliceVisualization(SinglePlaneVisualization):
         plane_index: Optional[int] = None,
         contrast_rescaling: Optional[str] = None,
         contrast: Optional[Tuple[int]] = None,
+        color_mode: Optional[str] = None,
     ):
         if plane_index is not None:
             self.update_data(plane_index=plane_index)
             self.update_data_to_plot()
 
-        super().update_figure(rotation_changed=rotation_changed, frame_index=frame_index, contrast_rescaling=contrast_rescaling, contrast=contrast)
+        super().update_figure(
+            rotation_changed=rotation_changed,
+            frame_index=frame_index,
+            contrast_rescaling=contrast_rescaling,
+            contrast=contrast,
+            color_mode=color_mode,
+        )
 
     def set_canvas_title(self):
         self.canvas_title = f"TwoPhotonSeries: {self.two_photon_series.name} - Planar slices of volume"

--- a/nwbwidgets/ophys/single_plane.py
+++ b/nwbwidgets/ophys/single_plane.py
@@ -94,6 +94,12 @@ class SinglePlaneVisualization(widgets.VBox):
         if not hasattr(self, "Controller"):  # First time this is called
             return 0
         return self.Controller.components[self.data_controller_name].components["RotationController"].rotation
+    
+    def get_color_mode(self) -> str:
+        """The color_mode attribute of the SinglePlaneDataController cannot be attached in a modifiable state."""
+        if not hasattr(self, "Controller"):  # First time this is called
+            return "greys"
+        return self.Controller.components["ImShowController"].components["ColorModeController"].color_mode
 
     def update_data_to_plot(self):
         rotation = self.get_rotation()
@@ -159,7 +165,7 @@ class SinglePlaneVisualization(widgets.VBox):
 
         contrast_rescaling = contrast_rescaling or self.Controller.auto_contrast_method.value
         contrast = contrast or self.Controller.manual_contrast_slider.value
-        color_mode = color_mode or self.Controller.color_mode_dropdown.value
+        color_mode = color_mode or self.get_color_mode()
         
         img_fig_kwargs = dict(color_continuous_scale=color_mode)
         if self.Controller.contrast_type_toggle.value == "Manual":
@@ -210,8 +216,7 @@ class SinglePlaneVisualization(widgets.VBox):
         self.Controller.manual_contrast_slider.observe(
             lambda change: self.update_canvas(contrast=change.new), names="value"
         )
-        self.Controller.color_mode_dropdown.observe(lambda change: self.update_canvas(color_mode=change.new), names="value")
-        self.Controller.color_mode_reverse_toggle.observe(
-            lambda change: self.update_canvas(color_mode=self.Controller.color_mode_dropdown.value),
-            names="value"
-        )
+        
+        # Rely on upstream controller observers to set the dynamic color mode value
+        self.Controller.color_mode_dropdown.observe(lambda change: self.update_canvas(color_mode=self.get_color_mode()), names="value")
+        self.Controller.color_mode_reverse_toggle.observe(lambda change: self.update_canvas(color_mode=self.get_color_mode()), names="value")

--- a/nwbwidgets/ophys/single_plane.py
+++ b/nwbwidgets/ophys/single_plane.py
@@ -160,7 +160,7 @@ class SinglePlaneVisualization(widgets.VBox):
         contrast_rescaling = contrast_rescaling or self.Controller.auto_contrast_method.value
         contrast = contrast or self.Controller.manual_contrast_slider.value
         color_mode = color_mode or self.Controller.color_mode_dropdown.value
-
+        
         img_fig_kwargs = dict(color_continuous_scale=color_mode)
         if self.Controller.contrast_type_toggle.value == "Manual":
             img_fig_kwargs.update(zmin=contrast[0], zmax=contrast[1])
@@ -211,3 +211,7 @@ class SinglePlaneVisualization(widgets.VBox):
             lambda change: self.update_canvas(contrast=change.new), names="value"
         )
         self.Controller.color_mode_dropdown.observe(lambda change: self.update_canvas(color_mode=change.new), names="value")
+        self.Controller.color_mode_reverse_toggle.observe(
+            lambda change: self.update_canvas(color_mode=self.Controller.color_mode_dropdown.value),
+            names="value"
+        )

--- a/nwbwidgets/ophys/single_plane.py
+++ b/nwbwidgets/ophys/single_plane.py
@@ -178,13 +178,10 @@ class SinglePlaneVisualization(widgets.VBox):
         # Solution is simply to regenerate the children when this change occurs.
         # If anyone can figure out how to adjust the layout properties of a figure
         # contained in a FigureWidget interactively, please refactor this accordingly.
-        #if "color_mode" in update_figure_kwargs:
         self.Canvas = go.FigureWidget(self.figure)
         self.Canvas.layout.title = self.canvas_title
         self.Canvas.update_xaxes(visible=False, showticklabels=False).update_yaxes(visible=False, showticklabels=False)
         self.children = (self.Canvas, self.Controller)
-        #else:
-        #    self.Canvas.data[0].update(self.figure.data[0])
 
     def set_canvas_title(self):
         """This can change in child classes."""


### PR DESCRIPTION
This shows how easy it is to modify/extend the structure established by the refactor of [#](https://github.com/NeurodataWithoutBorders/nwbwidgets/pull/241) - this adds a color bar for the imshow to allow flexible user-controlled coloration of the image data, inspired by the color choices of Fig1 in https://www.sciencedirect.com/science/article/pii/S009286741930621X

